### PR TITLE
UwU command image embed exploit fixed

### DIFF
--- a/thatkitebot/cogs/funstuffcog.py
+++ b/thatkitebot/cogs/funstuffcog.py
@@ -10,6 +10,7 @@ from thatkitebot.backend import url, util, cache
 from datetime import datetime
 from uwuipy import uwuipy
 import textwrap
+import re
 from unidecode import unidecode
 
 
@@ -285,7 +286,16 @@ class FunStuff(commands.Cog, name="fun commands"):
             # declare a new uwu object using the message id as seed
             uwu = uwuipy(seed)
             # convert the input string to ascii
-            msg = uwu.uwuify(unidecode(msg))
+            msg = unidecode(msg)
+
+            # if the user cant send images, make links not embed by surrounding them with <>
+            if not can_send_image(ctx):
+                links = r"(https?:\/\/[A-Za-z0-9\-._~!$&'()*+,;=:@\/?]+)"
+                msg = re.sub(links, r"<\1>" , msg)
+
+            # do the deed
+            msg = uwu.uwuify(msg)
+
             # if the message is longer than 2 000 characters
             if len(msg) > 2000:
                 # split it up while maintaining whole words

--- a/thatkitebot/cogs/uwucog.py
+++ b/thatkitebot/cogs/uwucog.py
@@ -8,7 +8,7 @@ from thatkitebot.cogs.settings import mods_can_change_settings
 from uwuipy import uwuipy
 import textwrap
 from unidecode import unidecode
-
+import re
 
 async def uwuify(message: str, id: int):
     uwu = uwuipy(id)
@@ -62,6 +62,12 @@ class UwuCog(commands.Cog, name="UwU Commands"):
             # convert the input string to ascii
             msg_len = len(message.content) + 20
             msg = unidecode(message.content)
+
+            # if the user cant embed links, make links not embed by surrounding them with <>
+            if not message.channel.permissions_for(message.author).embed_links:
+                links = r"(https?:\/\/[A-Za-z0-9\-._~!$&'()*+,;=:@\/?]+)"
+                msg = re.sub(links, r"<\1>" , msg)
+
             msg_small = textwrap.wrap(msg, msg_len)
             msg = await uwuify(msg_small[0], message.id)
             # split it up while maintaining whole words


### PR DESCRIPTION
Users can not embed image links anymore when they dont have permission to via +uwu or /uwu_user, etc. 