### PR TITLE
Fixed issue with kitebot sanitising mouser links

### DIFF
--- a/data/detrackparams.toml
+++ b/data/detrackparams.toml
@@ -178,14 +178,6 @@ params = "_all_"
 query = "&*(HQS|ts|ref.{1,})=[^&]*"
 fragment = "_all_"
 
-[domains.mouser]
-netloc = ".*mouser."
-netloc_dl = "_pref_"
-path = ""
-params = "_all_"
-query = "&*(qs)=[^&]*"
-fragment = "_all_"
-
 [LUT] # this is the lookup table, it's used to simplify the regex writing by replacing parts of it with a tag
 # the format:
 # _tag_ = "regex"


### PR DESCRIPTION
As far as I'm aware, mouser never adds tracking data to URLs (?) and this also fixes the issue with kitebot breaking mouser URLs (#93). I've tested this locally using docker, but it should be verified to see that it doesn't break anything else somehow.