### PR TITLE
Added new youtube tracking parameter

### DIFF
--- a/data/detrackparams.toml
+++ b/data/detrackparams.toml
@@ -151,7 +151,7 @@ netloc = ".*youtube."
 netloc_dl = "_pref_"
 path = ""
 params = "_all_"
-query = "&*(feature|kw)=[^&]*"
+query = "&*(feature|kw|si)=[^&]*"
 fragment = "_all_"
 
 [domains.walmart]


### PR DESCRIPTION
I noticed that youtube started adding ?si=<somevalue> as a additional parameter in urls. It's still new, and not everyone has that